### PR TITLE
added requirement for error from r5rs

### DIFF
--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -44,3 +44,5 @@
 
 (#%provide stream-null?)
 (define (stream-null? x) (null? x))
+
+(#%provide error)

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -5,6 +5,7 @@
                  current-print
                  flush-output
                  make-parameter
+                 error
                  void?)
            (rename racket/base racket:module-begin #%module-begin))
 


### PR DESCRIPTION
When trying to use the error function in sicp (e.g. Sec 2.1.3) I get an error:

`error: unbound identifier in module in: error`

This patch should provide the error function from R5RS.
