### PR TITLE
Add amb special form

### DIFF
--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -54,3 +54,30 @@
   (if (and (integer? n) (exact? n))
       (random n)
       (* n (random))))
+
+(#%provide amb)
+(define amb-fail '*)
+
+(define (initialize-amb-fail)
+  (set! amb-fail
+    (lambda ()
+      (display "amb tree exhausted"))))
+
+(initialize-amb-fail)
+
+(define call/cc call-with-current-continuation)
+
+(define-syntax amb
+  (syntax-rules ()
+    ((amb alts ...)
+     (let ((prev-amb-fail amb-fail))
+       (call/cc
+        (lambda (sk)
+          (call/cc
+           (lambda (fk)
+             (set! amb-fail
+               (lambda ()
+                 (set! amb-fail prev-amb-fail)
+                 (fk 'fail)))
+             (sk alts))) ...
+             (prev-amb-fail)))))))


### PR DESCRIPTION
The documentation mentions that `amb` is provided. But its not provided in `#lang sicp`. 
This is just copy-paste from [old pict language](https://github.com/sicp-lang/sicp/blob/master/sicp-pict/sicp.ss). 