### PR TITLE
change seconds to microseconds in (runtime) description

### DIFF
--- a/sicp-doc/sicp.scrbl
+++ b/sicp-doc/sicp.scrbl
@@ -54,7 +54,7 @@ then use @racket[#%require].
 }
 
 @defproc[(runtime) natural-number/c]{
-  Returns the current time measured as the number of seconds passed since a fixed beginning.
+  Returns the current time measured as the number of microseconds passed since a fixed beginning.
 }
 
 @defproc[(random [n positive?]) real?]{


### PR DESCRIPTION
Currently, the description of the (runtime) procedure says that (runtime) "returns the current time measured as the number of seconds..." However, main.rkt defines (runtime) as
`(define (runtime)
  (inexact->exact (truncate (* 1000 (current-inexact-milliseconds)))))`
which evaluates to microseconds. 