### PR TITLE
Add type version for `sicp-pict` and make some improvements to `sicp` and `sicp-pict`.

### DIFF
--- a/sicp-doc/sicp-manual.scrbl
+++ b/sicp-doc/sicp-manual.scrbl
@@ -14,6 +14,8 @@ to simply as SICP.
 
 The second @racket[sicp-pict] collection contains the picture language used in SICP.
 
+@local-table-of-contents[]
+
 @include-section["installation.scrbl"]
 @include-section["sicp.scrbl"]
 @include-section["sicp-pict.scrbl"]
@@ -21,4 +23,3 @@ The second @racket[sicp-pict] collection contains the picture language used in S
 @include-section["external-links.scrbl"]
 
 @index-section{}
-

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -6,7 +6,7 @@
                      (only-in racket/contract
                               -> any/c and/c or/c
                               listof contract? parameter/c
-                              real-in <=/c natural-number/c)
+                              real-in >/c <=/c natural-number/c)
                      (only-in racket/sequence sequence/c)
                      (only-in racket/class is-a?/c)
                      (only-in racket/draw

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -423,20 +423,20 @@ Painting turns a painter into an @emph{image snip} which can be displayed in DrR
 }
 
 @defproc[(paint [p painter/c]
-                [#:width width (and/c positive? integer?) 200]
-                [#:height height (and/c positive? integer?) 200])
+                [#:width  width  exact-positive-integer? 200]
+                [#:height height exact-positive-integer? 200])
          (is-a?/c image-snip%)]{
   Returns an image snip that contains the painter's image with
   the specified @racket[width] and @racket[height].
 }
 
 @deftogether[(@defproc[(paint-hi-res [p painter/c]
-                                     [#:width width (and/c positive? integer?) 200]
-                                     [#:height height (and/c positive? integer?) 200])
+                                     [#:width  width  exact-positive-integer? 200]
+                                     [#:height height exact-positive-integer? 200])
                        (is-a?/c image-snip%)]
               @defproc[(paint-hires [p painter/c]
-                                    [#:width width (and/c positive? integer?) 200]
-                                    [#:height height (and/c positive? integer?) 200])
+                                    [#:width  width  exact-positive-integer? 200]
+                                    [#:height height exact-positive-integer? 200])
                        (is-a?/c image-snip%)])]{
   Aliases of @racket[paint]. They are provided for compatibility with old texts.
 }

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -5,10 +5,11 @@
                      racket/base
                      (only-in racket/contract
                               -> any/c and/c or/c
-                              listof contract?
+                              listof contract? parameter/c
                               real-in <=/c natural-number/c)
+                     (only-in racket/sequence sequence/c)
                      (only-in racket/class is-a?/c)
-                     (only-in racket/draw bitmap% color%)
+                     (only-in racket/draw bitmap% bitmap-dc% color% pen% brush%)
                      (only-in racket/snip image-snip%)))
 
 @(define the-eval (make-base-eval))
@@ -409,6 +410,15 @@ The following painter values are built-in:
 @section{Painting}
 
 Painting turns a painter into an @emph{image snip} which can be displayed in DrRacket automatically.
+
+@deftogether[(@defthing[current-bm (parameter/c (or/c #f (is-a?/c bitmap%)))]
+              @defthing[current-dc (parameter/c (or/c #f (is-a?/c bitmap-dc%)))])]{
+  A painter needs to paint on something.
+  We will use a parameter  @racket[current-dc]  to hold the drawing context
+  of "what is currently being drawn to".
+  In practice this will hold the drawing context (@racket[current-dc])
+  for a bitmap (@racket[current-bm]).
+}
 
 @defproc[(paint [p painter/c]
                 [#:width width (and/c positive? integer?) 200]

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -378,6 +378,10 @@ Constructs a painter that paints all images on top of each other.}
 
 The following painter values are built-in:
 
+@defthing[blank painter/c]{
+  Draws nothing.
+}
+
 @deftogether[(@defthing[black painter/c]
               @defthing[white painter/c]
               @defthing[gray painter/c])]{

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -9,7 +9,10 @@
                               real-in <=/c natural-number/c)
                      (only-in racket/sequence sequence/c)
                      (only-in racket/class is-a?/c)
-                     (only-in racket/draw bitmap% bitmap-dc% color% pen% brush%)
+                     (only-in racket/draw
+                              bitmap% bitmap-dc%
+                              color% pen% brush%
+                              make-bitmap)
                      (only-in racket/snip image-snip%)))
 
 @(define the-eval (make-base-eval))
@@ -423,20 +426,29 @@ Painting turns a painter into an @emph{image snip} which can be displayed in DrR
 }
 
 @defproc[(paint [p painter/c]
-                [#:width  width  exact-positive-integer? 200]
-                [#:height height exact-positive-integer? 200])
+                [alpha? any/c #t]
+                [#:width width exact-positive-integer? 200]
+                [#:height height exact-positive-integer? 200]
+                [#:backing-scale backing-scale (>/c 0.0) 1.0])
          (is-a?/c image-snip%)]{
   Returns an image snip that contains the painter's image with
-  the specified @racket[width] and @racket[height].
+  the specified @racket[alpha?], @racket[width], @racket[height],
+  and @racket[backing-scale].
+
+  See also @racket[make-bitmap].
 }
 
-@deftogether[(@defproc[(paint-hi-res [p painter/c]
-                                     [#:width  width  exact-positive-integer? 200]
-                                     [#:height height exact-positive-integer? 200])
+@deftogether[(@defproc[(paint [p painter/c]
+                              [alpha? any/c #t]
+                              [#:width width exact-positive-integer? 200]
+                              [#:height height exact-positive-integer? 200]
+                              [#:backing-scale backing-scale (>/c 0.0) 1.0])
                        (is-a?/c image-snip%)]
-              @defproc[(paint-hires [p painter/c]
-                                    [#:width  width  exact-positive-integer? 200]
-                                    [#:height height exact-positive-integer? 200])
+              @defproc[(paint [p painter/c]
+                              [alpha? any/c #t]
+                              [#:width width exact-positive-integer? 200]
+                              [#:height height exact-positive-integer? 200]
+                              [#:backing-scale backing-scale (>/c 0.0) 1.0])
                        (is-a?/c image-snip%)])]{
   Aliases of @racket[paint]. They are provided for compatibility with old texts.
 }

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -194,7 +194,7 @@ the first vect to the endpoint of the second vect.
   (vects->segments (list (make-vect 1 2) (make-vect 3 4) (make-vect 5 6) (make-vect 7 8)))]
 }
 
-@section{COLORS, PENS, and BRUSHES}
+@section{Colors, Pens, and Brushes}
 @defproc[(color-object? [v any/c]) boolean?]{
   Defined as @racket[(is-a?/c color%)].
 }
@@ -303,9 +303,11 @@ segments (w.r.t. the unit square).}
 Constructs a painter that draws a stick figure given by the
 vects (w.r.t. the unit square).}
 
-@defproc[(procedure->painter [f (-> (real-in 0 1)
-                                    (real-in 0 1)
-                                    (or/c real? string? color-object?))]
+@defthing[painter-procedure/c contract?]{
+A contract that recognizes a procedure which can be used to create painter.
+}
+
+@defproc[(procedure->painter [f painter-procedure/c]
                              [size real? 100]) painter/c]{
 
 Creates painters from procedures. We assume that the procedure

--- a/sicp-doc/sicp-pict.scrbl
+++ b/sicp-doc/sicp-pict.scrbl
@@ -438,17 +438,17 @@ Painting turns a painter into an @emph{image snip} which can be displayed in DrR
   See also @racket[make-bitmap].
 }
 
-@deftogether[(@defproc[(paint [p painter/c]
-                              [alpha? any/c #t]
-                              [#:width width exact-positive-integer? 200]
-                              [#:height height exact-positive-integer? 200]
-                              [#:backing-scale backing-scale (>/c 0.0) 1.0])
+@deftogether[(@defproc[(paint-hi-res [p painter/c]
+                                     [alpha? any/c #t]
+                                     [#:width width exact-positive-integer? 200]
+                                     [#:height height exact-positive-integer? 200]
+                                     [#:backing-scale backing-scale (>/c 0.0) 1.0])
                        (is-a?/c image-snip%)]
-              @defproc[(paint [p painter/c]
-                              [alpha? any/c #t]
-                              [#:width width exact-positive-integer? 200]
-                              [#:height height exact-positive-integer? 200]
-                              [#:backing-scale backing-scale (>/c 0.0) 1.0])
+              @defproc[(paint-hires [p painter/c]
+                                    [alpha? any/c #t]
+                                    [#:width width exact-positive-integer? 200]
+                                    [#:height height exact-positive-integer? 200]
+                                    [#:backing-scale backing-scale (>/c 0.0) 1.0])
                        (is-a?/c image-snip%)])]{
   Aliases of @racket[paint]. They are provided for compatibility with old texts.
 }

--- a/sicp-doc/sicp.scrbl
+++ b/sicp-doc/sicp.scrbl
@@ -1,9 +1,12 @@
 #lang scribble/doc
 
 @(require scribble/manual scribble/eval
-          (for-label (except-in sicp #%app #%datum #%top true false identity error)
-                     (only-in racket require true false identity error
-                                     natural-number/c any/c)))
+          (for-label (except-in sicp #%app #%datum #%top)
+                     (only-in racket/base require list*)
+                     (only-in racket/contract
+                              any any/c
+                              and/c or/c not/c
+                              natural-number/c)))
 
 @title{SICP Language}
 @defmodule[sicp #:lang]
@@ -106,4 +109,5 @@ then use @racket[#%require].
 
 Additionally, @racket[true], @racket[false], @racket[raise], @racket[error],
 @racket[compose], @racket[compose1], @racket[identity],
-@racket[empty?], @racket[empty], and @racket[null] are provided from Racket.
+@racket[empty?], @racket[empty], @racket[null],
+@racket[add1], and @racket[sub1] are provided from Racket.

--- a/sicp-doc/sicp.scrbl
+++ b/sicp-doc/sicp.scrbl
@@ -32,26 +32,63 @@ then use @racket[#%require].
   An alias for @racket['()].
 }
 
-@defproc[(inc [x number?]) number?]{
+@deftogether[(@defproc[(inc [x number?]) number?]
+              @defproc[(1+  [x number?]) number?])]{
   Returns @racket[(+ x 1)].
 }
 
-@defproc[(dec [x number?]) number?]{
+@deftogether[(@defproc[(dec [x number?]) number?]
+              @defproc[(-1+ [x number?]) number?]
+              @defproc[(1-  [x number?]) number?])]{
   Returns @racket[(- x 1)].
 }
 
-@defthing[the-empty-stream stream?]{
+@deftogether[(@defthing[the-empty-stream stream?]
+              @defthing[empty-stream stream?])]{
   The null/empty stream.
 }
 
-@defform[(cons-stream first-expr rest-expr)]{
-  Produces a stream
+@deftogether[(@defform[(cons-stream first-expr rest-expr)]
+              @defform[(stream-cons first-expr rest-expr)])]{
+  Produces a stream whose first element is determined by
+  @racket[first-expr] and whose rest is determined by
+  @racket[rest-expr].
 }
 
-@defproc[(stream-null? [s stream?]) boolean?]{
+@defform[(stream v ...)]{
+  A shorthand for nested @racket[cons-stream]s ending with @racket[the-empty-stream].
+}
+
+@defform[(stream* v ... tail)]{
+  A shorthand for nested @racket[cons-stream]s, but the @racket[tail]
+  must produce a stream when it is forced, and that stream
+  is used as the rest of the stream instead of @racket[the-empty-stream].
+  Similar to @racket[list*] but for streams.
+}
+
+@deftogether[(@defproc[(stream-null?  [s stream?]) boolean?]
+              @defproc[(stream-empty? [s stream?]) boolean?])]{
   Returns @racket[#t] if @racket[s] is @racket[the-empty-stream],
   @racket[#f] otherwise.
 }
+
+@defproc[(stream? [v any/c]) boolean?]{
+  Returns @racket[#t] if @racket[v] is @racket[the-empty-stream] or a pair,
+  @racket[#f] otherwise.
+  Although the expectation is a pair whose second element is a promise,
+  @racket[stream?] doesn't check it, since @racket[promise?] is undefined.
+}
+
+@deftogether[(@defproc[(stream-car   [s (and/c stream? (not/c stream-null?))]) any]
+              @defproc[(stream-first [s (and/c stream? (not/c stream-null?))]) any])]{
+  Returns the value(s) of the first element in @racket[s].
+}
+
+@deftogether[(@defproc[(stream-cdr  [s (and/c stream? (not/c stream-null?))]) stream?]
+              @defproc[(stream-rest [s (and/c stream? (not/c stream-null?))]) stream?])]{
+  Returns a stream that is equivalent to @racket[s] without its first element.
+}
+
 
 @defproc[(runtime) natural-number/c]{
   Returns the current time measured as the number of microseconds passed since a fixed beginning.
@@ -67,4 +104,6 @@ then use @racket[#%require].
   The amb operator.
 }
 
-Additionally, @racket[true], @racket[false], @racket[identity], and @racket[error] are provided from Racket.
+Additionally, @racket[true], @racket[false], @racket[raise], @racket[error],
+@racket[compose], @racket[compose1], @racket[identity],
+@racket[empty?], @racket[empty], and @racket[null] are provided from Racket.

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -540,8 +540,9 @@
 ;;;
 ;;; Predefined Basic Painters
 ;;;
-(provide black white gray diagonal-shading mark-of-zorro einstein escher)
+(provide blank black white gray diagonal-shading mark-of-zorro einstein escher)
 
+(define blank            identity)
 (define black            (number->painter   0))
 (define white            (number->painter 255))
 (define gray             (number->painter 150))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -551,12 +551,12 @@
 (provide blank black white gray diagonal-shading mark-of-zorro einstein escher)
 
 (define blank            (λ (frame) (void)))
-(define black            (number->painter   0))
-(define white            (number->painter 255))
-(define gray             (number->painter 150))
-(define diagonal-shading (procedure->painter (λ (x y) (* 100 (+ x y)))))
-(define mark-of-zorro    (vects->painter (list (vect .1 .9) (vect .8 .9) (vect .1 .2) (vect .9 .3))))
-(define einstein         (bitmap->painter einstein-file))
+(define black            (procedure-rename (number->painter   0) 'black))
+(define white            (procedure-rename (number->painter 255) 'white))
+(define gray             (procedure-rename (number->painter 150) 'gray))
+(define diagonal-shading (procedure-rename (procedure->painter (λ (x y) (* 100 (+ x y)))) 'diagonal-shading))
+(define mark-of-zorro    (procedure-rename (vects->painter (list (vect .1 .9) (vect .8 .9) (vect .1 .2) (vect .9 .3))) 'mark-of-zorro))
+(define einstein         (procedure-rename (bitmap->painter einstein-file) 'einstein))
 
 ;;; Escher Example
 

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -249,10 +249,13 @@
 ;;;  Current Drawing Context
 ;;;
 
+(provide (contract-out [current-bm (parameter/c (or/c #f (is-a?/c bitmap%)))]
+                       [current-dc (parameter/c (or/c #f (is-a?/c bitmap-dc%)))]))
+
 ; A painter needs to paint on something.
 ; We will use a parameter  current-dc  to hold the drawing context
 ; of "what is currently being drawn to".
-; In practice this will hold the a drawing context for a bitmap.
+; In practice this will hold the drawing context for a bitmap.
 
 (define current-bm (make-parameter #f))
 (define current-dc (make-parameter #f))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -161,7 +161,7 @@
     (segment v w)))
 
 ;;;
-;;; COLORS, PENS, and BRUSHES
+;;; Colors, Pens, and Brushes
 ;;;
 
 (provide (contract-out

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -506,7 +506,8 @@
 
 (define superpose
   (case-lambda
-    [() blank]
+    [()        blank]
+    [(painter) painter]
     [painters
      (λ (frame)
        (for ([painter (in-list painters)])

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -504,10 +504,13 @@
 (define rotate180      (repeated rotate90 2))
 (define rotate270      (repeated rotate90 3))
 
-(define (superpose . painters)
-  (λ (frame)
-    (for ([painter (in-list painters)])
-      (painter frame))))
+(define superpose
+  (case-lambda
+    [() blank]
+    [painters
+     (λ (frame)
+       (for ([painter (in-list painters)])
+         (painter frame)))]))
 
 (define (beside painter1 painter2)
   (define split-point (vect .5 0.))
@@ -544,7 +547,7 @@
 ;;;
 (provide blank black white gray diagonal-shading mark-of-zorro einstein escher)
 
-(define blank            (superpose))
+(define blank            (λ (frame) (void)))
 (define black            (number->painter   0))
 (define white            (number->painter 255))
 (define gray             (number->painter 150))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -275,10 +275,6 @@
     (painter (frame (vect 0. 0.) (vect 1. 0.) (vect 0. 1.)))
     (make-object image-snip% bm)))
 
-; For compatibility with old texts.
-(define paint-hi-res paint)
-(define paint-hires  paint)
-
 ; Painters assume the image as coordinates (0,0) in the
 ; lower left corner and (1,1) in the upper right corner.
 ; We therefore need to set the initial transformation matrix
@@ -388,8 +384,9 @@
          painter-procedure/c
          ;
          paint
-         paint-hi-res
-         paint-hires
+         ; For compatibility with old texts.
+         (rename-out [paint paint-hi-res])
+         (rename-out [paint paint-hires])
          ;
 
          (contract-out [number->painter (-> byte? painter/c)]

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -260,9 +260,9 @@
 
 (define painter/c (-> frame? any/c))
 
-; To get a painting from a painter, we need to create a new
-; bitmap into which the painter can draw.
 (define (paint painter #:width [width 200] #:height [height 200])
+  ; To get a painting from a painter, we need to create a new
+  ; bitmap into which the painter can draw.
   (define-values (bm dc) (make-painter-bitmap width height))
   (parameterize ([current-bm bm]
                  [current-dc dc])

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -53,7 +53,7 @@
 
 (provide (contract-out
           [struct frame ([origin vect?] [edge1 vect?] [edge2 vect?])]       ; structure
-          [frame-coord-map     (-> frame?             (-> vect? vect?))]    
+          [frame-coord-map     (-> frame?             (-> vect? vect?))]
           [make-relative-frame (-> vect? vect? vect?  (-> frame? frame?))]))
 
 (struct frame (origin edge1 edge2)
@@ -106,7 +106,7 @@
   #:transparent)
 
 (define (compose-transformation t1 t2)
-  ; ((compose-trans t1 t2) v) = (t1 (t2 v))  
+  ; ((compose-trans t1 t2) v) = (t1 (t2 v))
   ; Use t2 to transform (x0,y0) into (x1,y1)
   ;   x1 = g x0 + h y0 + k
   ;   y1 = i x0 + j y0 + l
@@ -115,10 +115,10 @@
   ;   y2 = c x1 + d y1 + f
   ; The composed transformation is (computed by a CAS):
   ;   x2 = (a g + b i) x0 + (a h + b j) y0 + ak + bl + e
-  ;   y2 = (c g + d i) x0 + (c h + d j) y0 + ck + dl + f    
+  ;   y2 = (c g + d i) x0 + (c h + d j) y0 + ck + dl + f
   (match-define (trans a b c d e f) t1)
-  (match-define (trans g h i j k l) t2)  
-  (trans (+ (* a g) (* b i))   (+ (* a h) (* b j)) 
+  (match-define (trans g h i j k l) t2)
+  (trans (+ (* a g) (* b i))   (+ (* a h) (* b j))
          (+ (* c g) (* d i))   (+ (* c h) (* d j))
          (+ (* a k) (* b l) e) (+ (* c k) (* d l) f)))
 
@@ -161,48 +161,56 @@
     (segment v w)))
 
 ;;;
-;;; COLORS, PENS, AND, BRUSHES
+;;; COLORS, PENS, and BRUSHES
 ;;;
 
 (provide (contract-out
           [color-object?      (-> any/c boolean?)]
           [pen-object?        (-> any/c boolean?)]
           [brush-object?      (-> any/c boolean?)]
-          [new-color          any/c]
-          #;[new-color          (or/c (-> real? real? real?                    color-object?)
-                                      (-> (or/c number? string? color-object?) color-object?))]
-          [new-pen            (-> any/c pen-object?)]
-          [new-brush          (-> any/c brush-object?)]
-          [new-stipple-brush  (-> any/c brush-object?)]
+          [new-color          (case-> (-> (or/c real? string? color-object?) color-object?)
+                                      (-> real? real? real?                  color-object?)
+                                      (-> real? real? real?   (real-in 0 1)  color-object?))]
+          [new-pen            (-> (or/c string? color-object?) pen-object?)]
+          [new-brush          (-> (or/c string? color-object?) brush-object?)]
+          [new-stipple-brush  (-> (or/c #f (is-a?/c bitmap%))  brush-object?)]
           [black-color        color-object?]
           [white-color        color-object?]
           [black-pen          pen-object?]
           [black-brush        brush-object?]
           [transparent-brush  brush-object?]))
 
-(define (color-object? o) (and (object? o) (is-a? o color%)))
-(define (pen-object? o)   (and (object? o) (is-a? o pen%)))
-(define (brush-object? o) (and (object? o) (is-a? o brush%)))
+(define color-object? (is-a?/c color%))
+(define pen-object?   (is-a?/c pen%))
+(define brush-object? (is-a?/c brush%))
 
 (define new-color
-  (let () ; make a cache of colors in order to reuse them
-    (define colors (make-hash))
-    (λ ns
-      (hash-ref! colors ns
-                 (λ ()
-                   (match ns
-                     [(list (? number? n))        (let ([n (inexact->exact (floor n))])
-                                                    (make-object color% n n n))]
-                     [(list r g b)                (let ([r (inexact->exact (floor r))]
-                                                        [g (inexact->exact (floor g))]
-                                                        [b (inexact->exact (floor b))])
-                                                    (make-object color% r g b))]
-                     [(list (? string? s))        (make-object color% s)]                     
-                     [(list (? color-object? c))  c]
-                     [_ (error 'new-color)]))))))
+  (let ()
+    (define (real->byte r)
+      (define n (inexact->exact (floor r)))
+      (if (byte? n) n (raise-argument-error 'new-color "byte?" n)))
+    (define colors (make-hash))  ; make a cache of colors in order to reuse them
+    (case-lambda
+      [(a) (hash-ref! colors a
+                      (λ ()
+                        (match a
+                          [(? real? r)
+                           (define b (real->byte r))
+                           (make-object color% b b b)]
+                          [(? string? s) (make-object color% s)]
+                          [(? color-object? c) c])))]
+      [(r g b) (new-color r g b 1.0)]
+      [(r g b a) (hash-ref! colors (list r g b a)
+                            (λ ()
+                              (unless ((real-in 0 1) a)
+                                (raise-argument-error 'new-color "(real-in 0 1)" a))
+                              (let ([r (real->byte r)]
+                                    [g (real->byte g)]
+                                    [b (real->byte b)])
+                                (make-object color% r g b a))))])))
 
 (define new-pen ; draws lines and outlines
-  (let () 
+  (let ()
     (define pens (make-hash))  ; make a cache of pens in order to reuse them
     (λ (color) (hash-ref! pens color
                           (λ () ; a pen of width 0 means "as thin as possible"
@@ -214,7 +222,8 @@
                                  [stipple #f]))))))
 
 (define new-brush ; fill in areas
-  (let () (define brushes (make-hash))
+  (let ()
+    (define brushes (make-hash))   ; make a cache of brushes in order to reuse them
     (λ (color) (hash-ref! brushes color
                           (λ ()
                             (new brush%
@@ -222,11 +231,14 @@
                                  [style 'solid]))))))
 
 (define new-stipple-brush ; fill in area with bitmap
-  (let () (define brushes (make-hash))
+  (let ()
+    (define brushes (make-hash))   ; make a cache of brushes in order to reuse them
     (λ (bm) (hash-ref! brushes bm
-                       (λ () (new brush% [style 'solid] [stipple bm]))))))
+                       (λ () (new brush%
+                                   [style 'solid]
+                                   [stipple bm]))))))
 
-;; Useful pens and brushes
+;; Useful colors, pens and brushes
 (define black-color       (new-color "black"))
 (define white-color       (new-color "white"))
 (define black-pen         (new-pen   "black"))
@@ -272,7 +284,7 @@
   (define dc (new bitmap-dc% [bitmap bm]))
   (send dc set-pen black-pen)
   (send dc set-brush black-brush)
-  ; (send dc set-smoothing 'smoothed)  
+  ; (send dc set-smoothing 'smoothed)
   (define w (* 1. width))
   (define h (* 1. height))
   ; Map unit square to screen coordinates - also flip y-axis
@@ -282,6 +294,16 @@
   (values bm dc))
 
 
+;;;
+;;; Syntactic Sugar
+;;;
+
+(provide echo
+         with-transformation
+         with-frame
+         with-pen
+         with-brush)
+
 ; For debugging: print the paint expression then paint.
 ; This makes it easy to see the expression that was used to produce an image.
 (define-syntax (echo stx)
@@ -290,18 +312,14 @@
      #'(begin (displayln 'painter-expr)
               (paint painter-expr))]))
 
-;;;
-;;; Syntactic Sugar
-;;;
-
 ; SYNTAX  (with-transformation transformation body ...)
-;   Store the initial-matrix of thed rawing context given by current-dc.
-;   Install  transformation  as the initial-matrix
-;   Evaluate body
+;   Store the initial-matrix of the drawing context given by current-dc.
+;   Install transformation as the initial-matrix
+;   Evaluate body ...
 ;   Restore the saved initial-matrix
 (define-syntax (with-transformation stx)
   (syntax-parse stx
-    [(_with-transformation transformation body ...)
+    [(_ transformation body ...)
      (syntax/loc stx
        (let ()
          (define dc (current-dc))
@@ -321,7 +339,7 @@
 ;   is given by the transformation corresponding to frame.
 (define-syntax (with-frame stx)
   (syntax-parse stx
-    [(_with-frame frame #:who who body ...)
+    [(_ frame #:who who body ...)
      (syntax/loc stx
        (begin
          (unless (current-dc)
@@ -333,7 +351,7 @@
 ;   Evaluate body ... while pen is installed in the drawing context given by current-dc
 (define-syntax (with-pen stx)
   (syntax-parse stx
-    [(_with-pen pen body ...)
+    [(_ pen body ...)
      (syntax/loc stx
        (let ()
          (define dc (current-dc))
@@ -347,7 +365,7 @@
 ;   Evaluate body ... while brush is installed in the drawing context given by current-dc
 (define-syntax (with-brush stx)
   (syntax-parse stx
-    [(_with-brush brush body ...)
+    [(_ brush body ...)
      (syntax/loc stx
        (let ()
          (define dc (current-dc))
@@ -362,25 +380,22 @@
 
 (provide painter/c
          ;
-         with-transformation
-         with-frame
-         with-pen
-         with-brush
-         ;
          paint
          paint-hi-res
          paint-hires
          ;
 
-         (contract-out [number->painter (-> (and/c natural-number/c (<=/c 255)) any/c)]
-                       [color->painter (-> (is-a?/c color%) painter/c)]
-                       [segments->painter (-> (sequence/c segment?) any/c)]
+         (contract-out [number->painter (-> byte? painter/c)]
+                       [color->painter (-> color-object? painter/c)]
+                       [segments->painter (-> (sequence/c segment?) painter/c)]
                        [vects->painter (-> (sequence/c vect?) painter/c)]
-                       [procedure->painter (-> procedure? any/c)]
-                       [bitmap->painter (-> (or/c path-string?
-                                                  (is-a?/c bitmap%)) any/c)]
-                       [load-painter (-> (or/c path-string?
-                                               (is-a?/c bitmap%)) any/c)]))
+                       [procedure->painter (->* ((-> (real-in 0 1)
+                                                     (real-in 0 1)
+                                                     (or/c real? string? color-object?)))
+                                                (real?)
+                                                painter/c)]
+                       [bitmap->painter (-> (or/c path-string? (is-a?/c bitmap%)) painter/c)]
+                       [load-painter (-> (or/c path-string? (is-a?/c bitmap%)) painter/c)]))
 
 ;;; Color Painter
 ;;;     A color painter fills the unit square with a solid color
@@ -396,10 +411,7 @@
 
 ;;; Number Painter
 ;;;     A number painter is a color painter that draws a gray color from 0 to 255.
-(define (number->painter number-or-color)
-  (define n number-or-color)
-  (unless (and (number? n) (<= 0 n 255))
-    (raise-type-error 'number->painter "number between 0 and 255" n))
+(define (number->painter n)
   (color->painter (new-color n)))
 
 
@@ -433,7 +445,7 @@
   (define w (* 1. (send bm get-width)))
   (define h (* 1. (send bm get-height)))
   (send flipped-dc set-initial-matrix (vector 1 0 0 -1 0 h))
-  (send flipped-dc draw-bitmap bm 0 0)  
+  (send flipped-dc draw-bitmap bm 0 0)
   (λ (frame)
     (with-frame frame #:who bitmap->painter
       (send (current-dc) draw-bitmap-section-smooth
@@ -448,7 +460,7 @@
 
 ;;; Procedure Painter
 (define (procedure->painter f [size 100])
-  ; f : vect -> color
+  ; f : ((real-in 0 1) (real-in 0 1) -> (or/c real? string? color-object?))
   (define bm (make-object bitmap% size size))
   (define dc (new bitmap-dc% [bitmap bm]))
   (define size.0 (* 1.0 size))
@@ -479,7 +491,7 @@
 ;; See SICP for a description of these painters
 (provide transform-painter
          flip-horiz flip-vert rotate90 rotate180 rotate270
-         superpose beside beside3 above3 below)
+         superpose beside beside3 above above3 below)
 
 (define (transform-painter painter origin corner1 corner2)
   (compose painter (make-relative-frame origin corner1 corner2)))
@@ -492,30 +504,36 @@
 
 (define (superpose . painters)
   (λ (frame)
-    (for ([painter painters])
+    (for ([painter (in-list painters)])
       (painter frame))))
 
 (define (beside painter1 painter2)
   (define split-point (vect .5 0.))
   (superpose
-   (transform-painter painter1 zero-vector split-point (vect 0. 1.))
-   (transform-painter painter2 split-point (vect 1 0)  (vect .5 1.))))
+   (transform-painter painter1 zero-vector split-point  (vect 0. 1.))
+   (transform-painter painter2 split-point (vect 1. 0.) (vect .5 1.))))
 
 (define (beside3 painter1 painter2 painter3)
   (define split-point1 (vect (/ 1. 3) 0.))
-  (define split-point2 (vect (/ 2. 3) 0.))  
+  (define split-point2 (vect (/ 2. 3) 0.))
   (superpose
     (transform-painter painter1 zero-vector  split-point1  (vect    0.    1.))
     (transform-painter painter2 split-point1 split-point2  (vect (/ 1. 3) 1.))
     (transform-painter painter3 split-point2 (vect 1. 0.)  (vect (/ 2. 3) 1.))))
 
-(define (above3 painter1 painter2 painter3)
-  (define 1/3. (/ 1. 3.))
-  (define 2/3. (/ 2. 3.))
+(define (above painter1 painter2)
+  (define split-point (vect 0. .5))
   (superpose
-   (transform-painter painter1 (vect 0. 2/3.) (vect 1. 2/3.) (vect 0.   1.))
-   (transform-painter painter2 (vect 0. 1/3.) (vect 1. 1/3.) (vect 0. 2/3.))
-   (transform-painter painter3 (vect 0. 0.)   (vect 1. 0.)   (vect 0. 1/3.))))
+   (transform-painter painter1 split-point (vect 1. .5) (vect 0. 1.))
+   (transform-painter painter2 zero-vector (vect 1. 0.) split-point)))
+
+(define (above3 painter1 painter2 painter3)
+  (define split-point1 (vect 0. (/ 1. 3)))
+  (define split-point2 (vect 0. (/ 2. 3)))
+  (superpose
+   (transform-painter painter1 split-point2 (vect 1. (/ 2. 3)) (vect 0. 1.))
+   (transform-painter painter2 split-point1 (vect 1. (/ 1. 3)) split-point2)
+   (transform-painter painter3 zero-vector  (vect 1. 0.)       split-point1)))
 
 (define (below painter1 painter2)
   (rotate270 (beside (rotate90 painter2)
@@ -525,7 +543,6 @@
 ;;; Predefined Basic Painters
 ;;;
 (provide black white gray diagonal-shading mark-of-zorro einstein escher)
-(provide echo)
 
 (define black            (number->painter   0))
 (define white            (number->painter 255))
@@ -618,7 +635,7 @@
   (define side2   (quartet side1 side1 (rot t) t))
   (define u       (cycle (rot q)))
   (define corner1 (quartet b b b u))
-  (define corner2 (quartet corner1 side1 (rot side1) u))  
+  (define corner2 (quartet corner1 side1 (rot side1) u))
   (define corner  (nonet   corner2     side2    side2
                            (rot side2)     u     (rot t)
                            (rot side2)  (rot t)    q))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -546,7 +546,7 @@
 ;;;
 (provide blank black white gray diagonal-shading mark-of-zorro einstein escher)
 
-(define blank            identity)
+(define blank            (superpose))
 (define black            (number->painter   0))
 (define white            (number->painter 255))
 (define gray             (number->painter 150))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -535,9 +535,7 @@
    (transform-painter painter2 split-point1 (vect 1. (/ 1. 3)) split-point2)
    (transform-painter painter3 zero-vector  (vect 1. 0.)       split-point1)))
 
-(define (below painter1 painter2)
-  (rotate270 (beside (rotate90 painter2)
-                     (rotate90 painter1))))
+(define (below painter1 painter2) (above painter2 painter1))
 
 ;;;
 ;;; Predefined Basic Painters
@@ -614,9 +612,6 @@
 
 (define (escher)
   ; combinators
-  (define (above p1 p2)
-    (below p2
-           p1))
   (define (quartet p1 p2 p3 p4)
     (above (beside p1 p2)
            (beside p3 p4)))
@@ -636,9 +631,9 @@
   (define u       (cycle (rot q)))
   (define corner1 (quartet b b b u))
   (define corner2 (quartet corner1 side1 (rot side1) u))
-  (define corner  (nonet   corner2     side2    side2
-                           (rot side2)     u     (rot t)
-                           (rot side2)  (rot t)    q))
+  (define corner  (nonet corner2      side2    side2
+                         (rot side2)      u  (rot t)
+                         (rot side2) (rot t)      q))
   (define square-limit (cycle corner))
   square-limit)
 

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -202,8 +202,6 @@
       [(r g b) (new-color r g b 1.0)]
       [(r g b a) (hash-ref! colors (list r g b a)
                             (λ ()
-                              (unless ((real-in 0 1) a)
-                                (raise-argument-error 'new-color "(real-in 0 1)" a))
                               (let ([r (real->byte r)]
                                     [g (real->byte g)]
                                     [b (real->byte b)])

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -504,10 +504,10 @@
 (define rotate180      (repeated rotate90 2))
 (define rotate270      (repeated rotate90 3))
 
-(define superpose
-  (case-lambda
-    [()        blank]
-    [(painter) painter]
+(define (superpose . painter*)
+  (match (remove* (list blank) painter*)
+    ['()         blank]
+    [`(,painter) painter]
     [painters
      (λ (frame)
        (for ([painter (in-list painters)])

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -382,6 +382,7 @@
 ;;;
 
 (provide painter/c
+         painter-procedure/c
          ;
          paint
          paint-hi-res
@@ -392,11 +393,7 @@
                        [color->painter (-> color-object? painter/c)]
                        [segments->painter (-> (sequence/c segment?) painter/c)]
                        [vects->painter (-> (sequence/c vect?) painter/c)]
-                       [procedure->painter (->* ((-> (real-in 0 1)
-                                                     (real-in 0 1)
-                                                     (or/c real? string? color-object?)))
-                                                (real?)
-                                                painter/c)]
+                       [procedure->painter (->* (painter-procedure/c) (real?) painter/c)]
                        [bitmap->painter (-> (or/c path-string? (is-a?/c bitmap%)) painter/c)]
                        [load-painter (-> (or/c path-string? (is-a?/c bitmap%)) painter/c)]))
 
@@ -462,6 +459,10 @@
 (define load-painter bitmap->painter)
 
 ;;; Procedure Painter
+(define painter-procedure/c
+  (-> (real-in 0 1)
+      (real-in 0 1)
+      (or/c real? string? color-object?)))
 (define (procedure->painter f [size 100])
   ; f : ((real-in 0 1) (real-in 0 1) -> (or/c real? string? color-object?))
   (define bm (make-object bitmap% size size))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -509,9 +509,11 @@
     ['()         blank]
     [`(,painter) painter]
     [painters
-     (λ (frame)
-       (for ([painter (in-list painters)])
-         (painter frame)))]))
+     (define superposed
+       (λ (frame)
+         (for ([painter (in-list painters)])
+           (painter frame))))
+     superposed]))
 
 (define (beside painter1 painter2)
   (define split-point (vect .5 0.))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -260,10 +260,15 @@
 
 (define painter/c (-> frame? any/c))
 
-(define (paint painter #:width [width 200] #:height [height 200])
+(define (paint painter
+               [alpha? #t]
+               #:width  [width 200]
+               #:height [height 200]
+               #:backing-scale [backing-scale 1.0])
   ; To get a painting from a painter, we need to create a new
   ; bitmap into which the painter can draw.
-  (define-values (bm dc) (make-painter-bitmap width height))
+  (define-values (bm dc)
+    (make-painter-bitmap width height alpha? #:backing-scale backing-scale))
   (parameterize ([current-bm bm]
                  [current-dc dc])
     (send dc scale 0.99 0.99) ; make the entire unit square visible
@@ -280,8 +285,8 @@
 ; such that both axis are scaled and the y-axis is flipped.
 ; Flipping the y-axis also implies we need to translate
 ; the origin in the y-direction
-(define (make-painter-bitmap width height)
-  (define bm (make-bitmap width height))
+(define (make-painter-bitmap width height alpha? #:backing-scale backing-scale)
+  (define bm (make-bitmap width height alpha? #:backing-scale backing-scale))
   (define dc (new bitmap-dc% [bitmap bm]))
   (send dc set-pen black-pen)
   (send dc set-brush black-brush)

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -290,7 +290,7 @@
   (define dc (new bitmap-dc% [bitmap bm]))
   (send dc set-pen black-pen)
   (send dc set-brush black-brush)
-  ; (send dc set-smoothing 'smoothed)
+  #;(send dc set-smoothing 'smoothed)
   (define w (* 1. width))
   (define h (* 1. height))
   ; Map unit square to screen coordinates - also flip y-axis
@@ -335,7 +335,7 @@
            ; transform frame coordinates into input coordinates of current transform
            (compose-transformation old-transformation transformation))
          (send dc set-initial-matrix (transformation->vector new-transformation))
-         ; (send dc transform (transformation->vector transformation))
+         #;(send dc transform (transformation->vector transformation))
          (begin0
            (begin body ...)
            (send dc set-initial-matrix old-vector))))]))
@@ -651,4 +651,4 @@
   (define square-limit (cycle corner))
   square-limit)
 
-;(echo (escher))
+#;(echo (escher))

--- a/sicp-pict/main.rkt
+++ b/sicp-pict/main.rkt
@@ -632,7 +632,7 @@
     (quartet      p1  (rot (rot (rot p1)))
              (rot p1)      (rot (rot p1))))
   (define rot     rotate90)
-  (define b       white) ; blank
+  (define b       blank)
   (define-values (p q r s) (values P Q R S))
   (define t       (quartet p q r s))
   (define side1   (quartet b b (rot t) t))

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -19,14 +19,13 @@
                      (provide id)
                      (define id expr))]))
 
-(provide true false error
+(provide true false
+         raise error
          compose compose1 identity
-         empty empty? null
+         empty? empty null
          add1 sub1
          (rename-out
           [null  nil]
-          [null  the-empty-stream]
-          [null? stream-null?]
           [add1 inc]
           [sub1 dec]
           [add1 1+]
@@ -39,10 +38,31 @@
       (racket:random n)
       (* n (racket:random))))
 
-(provide cons-stream)
+(provide cons-stream stream* stream
+         (rename-out
+          [the-empty-stream empty-stream]
+          [cons-stream      stream-cons]
+          [stream-null?     stream-empty?]
+          [stream-car       stream-first]
+          [stream-cdr       stream-rest]))
 (define-syntax cons-stream
   (syntax-rules ()
     [(_ A B) (r5rs:cons A (r5rs:delay B))]))
+(define-syntax stream*
+  (syntax-rules ()
+    [(_ A) A]
+    [(_ A B ...) (cons-stream A (stream* B ...))]))
+(define-syntax stream
+  (syntax-rules ()
+    [(_ A ...) (stream* A ... the-empty-stream)]))
+(define+provide the-empty-stream '())
+(define+provide stream-null? null?)
+(define+provide (stream? v)
+  (or (stream-null? v)
+      (and (r5rs:pair? v)
+           #;(r5rs:promise? (r5rs:cdr v)))))
+(define+provide stream-car r5rs:car)
+(define+provide stream-cdr (compose1 r5rs:force r5rs:cdr))
 
 
 (provide amb)

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -19,11 +19,16 @@
                      (provide id)
                      (define id expr))]))
 
-(provide true)
-(provide false)
-(provide error)
-(provide identity)
 (provide
+ true
+ false
+ error
+ compose
+ compose1
+ identity
+ null
+ add1
+ sub1
  (rename-out
   [null  nil]
   [null  the-empty-stream]

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -25,7 +25,7 @@
          empty? empty null
          add1 sub1
          (rename-out
-          [null  nil]
+          [null nil]
           [add1 inc]
           [sub1 dec]
           [add1 1+]

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -23,11 +23,16 @@
 (provide false)
 (provide error)
 (provide identity)
-(define+provide nil '())
-(define+provide the-empty-stream '())
-(define+provide stream-null? null?)
-(define+provide (inc x) (+ x 1))
-(define+provide (dec x) (- x 1))
+(provide
+ (rename-out
+  [null  nil]
+  [null  the-empty-stream]
+  [null? stream-null?]
+  [add1 inc]
+  [sub1 dec]
+  [add1 1+]
+  [sub1 1-]
+  [sub1 -1+]))
 (define+provide (runtime)
   (inexact->exact (truncate (* 1000 (current-inexact-milliseconds)))))
 (define+provide (random n)

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -11,9 +11,7 @@
 
 (define-syntax (define+provide stx)
   (syntax-case stx ()
-    [(_ (id . args) . body) #'(begin
-                                (provide id)
-                                (define (id . args) . body))]
+    [(_ (id . args) . body) #'(define+provide id (λ args . body))]
     [(_ id expr) #'(begin
                      (provide id)
                      (define id

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -19,25 +19,19 @@
                      (provide id)
                      (define id expr))]))
 
-(provide
- true
- false
- error
- compose
- compose1
- identity
- null
- add1
- sub1
- (rename-out
-  [null  nil]
-  [null  the-empty-stream]
-  [null? stream-null?]
-  [add1 inc]
-  [sub1 dec]
-  [add1 1+]
-  [sub1 1-]
-  [sub1 -1+]))
+(provide true false error
+         compose compose1 identity
+         empty empty? null
+         add1 sub1
+         (rename-out
+          [null  nil]
+          [null  the-empty-stream]
+          [null? stream-null?]
+          [add1 inc]
+          [sub1 dec]
+          [add1 1+]
+          [sub1 1-]
+          [sub1 -1+]))
 (define+provide (runtime)
   (inexact->exact (truncate (* 1000 (current-inexact-milliseconds)))))
 (define+provide (random n)

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -17,8 +17,9 @@
     [(_ id expr) #'(begin
                      (provide id)
                      (define id
-                       (let ([id expr])
-                         (if (procedure? id)
+                       (letrec ([id expr])
+                         (if (and (procedure? id)
+                                  (not (eq? (object-name id) 'id)))
                              (procedure-rename id 'id)
                              id))))]))
 

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -21,15 +21,13 @@
 (provide true false
          raise error
          compose compose1 identity
-         empty? empty null
-         add1 sub1
-         (rename-out
-          [null nil]
-          [add1 inc]
-          [sub1 dec]
-          [add1 1+]
-          [sub1 1-]
-          [sub1 -1+]))
+         empty? empty null)
+(define+provide (inc x) (add1 x))
+(define+provide (dec x) (sub1 x))
+(define+provide (1+  x) (add1 x))
+(define+provide (1-  x) (sub1 x))
+(define+provide (-1+ x) (sub1 x))
+(define+provide nil '())
 (define+provide (runtime)
   (inexact->exact (truncate (* 1000 (current-inexact-milliseconds)))))
 (define+provide (random n)
@@ -55,13 +53,13 @@
   (syntax-rules ()
     [(_ A ...) (stream* A ... the-empty-stream)]))
 (define+provide the-empty-stream '())
-(define+provide stream-null? null?)
+(define+provide (stream-null? v) (null? v))
 (define+provide (stream? v)
   (or (stream-null? v)
       (and (r5rs:pair? v)
            #;(r5rs:promise? (r5rs:cdr v)))))
-(define+provide stream-car r5rs:car)
-(define+provide stream-cdr (compose1 r5rs:force r5rs:cdr))
+(define+provide (stream-car s) (r5rs:car s))
+(define+provide (stream-cdr s) (r5rs:force (r5rs:cdr s)))
 
 
 (provide amb)

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -2,12 +2,11 @@
 
 (require racket/provide
          (prefix-in r5rs: r5rs)
-         (rename-in racket [random racket:random]))
+         (only-in r5rs [lambda r5rs:λ])
+         (only-in racket/base [random racket:random]))
 
 (provide (filtered-out (λ (name) (regexp-replace #px"^r5rs:" name ""))
-                       (combine-out
-                        (except-out (all-from-out r5rs) r5rs:#%module-begin)
-                        (rename-out [r5rs:lambda r5rs:λ])))
+                       (except-out (all-from-out r5rs) r5rs:#%module-begin))
          (rename-out [module-begin #%module-begin]))
 
 (define-syntax (define+provide stx)

--- a/sicp/main.rkt
+++ b/sicp/main.rkt
@@ -16,17 +16,21 @@
                                 (define (id . args) . body))]
     [(_ id expr) #'(begin
                      (provide id)
-                     (define id expr))]))
+                     (define id
+                       (let ([id expr])
+                         (if (procedure? id)
+                             (procedure-rename id 'id)
+                             id))))]))
 
 (provide true false
          raise error
          compose compose1 identity
          empty? empty null)
-(define+provide (inc x) (add1 x))
-(define+provide (dec x) (sub1 x))
-(define+provide (1+  x) (add1 x))
-(define+provide (1-  x) (sub1 x))
-(define+provide (-1+ x) (sub1 x))
+(define+provide inc add1)
+(define+provide dec sub1)
+(define+provide 1+  add1)
+(define+provide 1-  sub1)
+(define+provide -1+ sub1)
 (define+provide nil '())
 (define+provide (runtime)
   (inexact->exact (truncate (* 1000 (current-inexact-milliseconds)))))
@@ -53,13 +57,13 @@
   (syntax-rules ()
     [(_ A ...) (stream* A ... the-empty-stream)]))
 (define+provide the-empty-stream '())
-(define+provide (stream-null? v) (null? v))
+(define+provide stream-null? null?)
 (define+provide (stream? v)
   (or (stream-null? v)
       (and (r5rs:pair? v)
            #;(r5rs:promise? (r5rs:cdr v)))))
-(define+provide (stream-car s) (r5rs:car s))
-(define+provide (stream-cdr s) (r5rs:force (r5rs:cdr s)))
+(define+provide stream-car r5rs:car)
+(define+provide stream-cdr (compose1 r5rs:force r5rs:cdr))
 
 
 (provide amb)

--- a/typed/sicp-pict.rkt
+++ b/typed/sicp-pict.rkt
@@ -1,0 +1,4 @@
+#lang typed/racket/base
+
+(require "sicp-pict/main.rkt")
+(provide (all-from-out "sicp-pict/main.rkt"))

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -102,6 +102,7 @@
   ;;;
   ;;; Predefined Basic Painters
   ;;;
+  [blank            Painter]
   [black            Painter]
   [white            Painter]
   [gray             Painter]

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -72,9 +72,24 @@
   ;;;
   ;;; Primitive Painters
   ;;;
-  [paint              (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
-  [paint-hires        (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
-  [paint-hi-res       (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
+  [paint        (->* (Painter)
+                     (Any
+                      #:width  Positive-Integer
+                      #:height Positive-Integer
+                      #:backing-scale Positive-Real)
+                     (Instance Image-Snip%))]
+  [paint-hires  (->* (Painter)
+                     (Any
+                      #:width  Positive-Integer
+                      #:height Positive-Integer
+                      #:backing-scale Positive-Real)
+                     (Instance Image-Snip%))]
+  [paint-hi-res (->* (Painter)
+                     (Any
+                      #:width  Positive-Integer
+                      #:height Positive-Integer
+                      #:backing-scale Positive-Real)
+                     (Instance Image-Snip%))]
   [number->painter    (-> Byte Painter)]
   [color->painter     (-> (Instance Color%) Painter)]
   [segments->painter  (-> (Sequenceof Segment) Painter)]

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -1,0 +1,120 @@
+#lang typed/racket/base
+
+(require typed/racket/unsafe
+         typed/racket/draw
+         typed/racket/snip)
+
+
+(require (only-in "../../sicp-pict/main.rkt"
+                  ;;;
+                  ;;; Syntactic Sugar
+                  ;;;
+                  with-transformation
+                  with-frame
+                  with-pen
+                  with-brush
+                  echo))
+
+(define-type Vect    vect)
+(define-type Frame   frame)
+(define-type Trans   trans)
+(define-type Segment segment)
+(define-type Painter (-> Frame Any))
+
+(require/typed/provide "../../sicp-pict/main.rkt"
+  ;;;
+  ;;; Vects
+  ;;;
+  [#:struct vect ([x : Real] [y : Real])]
+  [vector-xcor  (-> Vect Real)]
+  [vector-ycor  (-> Vect Real)]
+  [vector-add   (-> Vect Vect Vect)]
+  [vector-sub   (-> Vect Vect Vect)]
+  [vector-scale (-> Real Vect Vect)]
+  [zero-vector  Vect]
+
+  ;;;
+  ;;; Frames
+  ;;;
+  [#:struct frame ([origin : Vect] [edge1 : Vect] [edge2 : Vect])]
+  [frame-coord-map     (-> Frame (-> Vect Vect))]
+  [make-relative-frame (-> Vect Vect Vect (-> Frame Frame))]
+
+  ;;;
+  ;;; Transformations
+  ;;;
+  [#:struct trans ([xx : Real] [xy : Real] [yx : Real] [yy : Real] [x0 : Real] [y0 : Real])]
+  [compose-transformation (-> Trans Trans Trans)]
+  [vector->transformation (-> (Vector Real Real Real Real Real Real) Trans)]
+  [transformation->vector (-> Trans (Vector Real Real Real Real Real Real))]
+  [frame->transformation  (-> Frame Trans)]
+
+  ;;;
+  ;;; Segments
+  ;;;
+  [#:struct segment ([start : Vect] [end : Vect])]
+  [vects->segments (-> (Sequenceof Vect) (Listof Segment))]
+
+  ;;;
+  ;;; COLORS, PENS, AND, BRUSHES
+  ;;;
+  [new-color         (case-> (->* (Real Real Real) (Real) (Instance Color%))
+                             (-> (U Number String (Instance Color%)) (Instance Color%)))]
+  [new-pen           (-> (U String (Instance Color%)) (Instance Pen%))]
+  [new-brush         (-> (U String (Instance Color%)) (Instance Brush%))]
+  [new-stipple-brush (-> (Option (Instance Bitmap%))  (Instance Brush%))]
+  [black-color       (Instance Color%)]
+  [white-color       (Instance Color%)]
+  [black-pen         (Instance Pen%)]
+  [black-brush       (Instance Brush%)]
+  [transparent-brush (Instance Brush%)]
+
+  ;;;
+  ;;; Primitive Painters
+  ;;;
+  [paint              (-> Painter [#:width Natural] [#:height Natural] (Instance Image-Snip%))]
+  [paint-hires        (-> Painter [#:width Natural] [#:height Natural] (Instance Image-Snip%))]
+  [paint-hi-res       (-> Painter [#:width Natural] [#:height Natural] (Instance Image-Snip%))]
+  [number->painter    (-> Byte Painter)]
+  [color->painter     (-> (Instance Color%) Painter)]
+  [segments->painter  (-> (Sequenceof Segment) Painter)]
+  [vects->painter     (-> (Sequenceof Vect) Painter)]
+  [procedure->painter (->* ((-> Real Real (U Number String (Instance Color%)))) (Real) Painter)]
+  [bitmap->painter    (-> (U Path-String (Instance Bitmap%)) Painter)]
+  [load-painter       (-> (U Path-String (Instance Bitmap%)) Painter)]
+
+  ;;;
+  ;;; Higher Order Painters
+  ;;;
+  [transform-painter (-> Painter Vect Vect Vect (-> Painter Painter))]
+  [flip-horiz        (-> Painter Painter)]
+  [flip-vert         (-> Painter Painter)]
+  [rotate90          (-> Painter Painter)]
+  [rotate180         (-> Painter Painter)]
+  [rotate270         (-> Painter Painter)]
+  [superpose         (-> Painter * Painter)]
+  [beside            (-> Painter Painter Painter)]
+  [beside3           (-> Painter Painter Painter Painter)]
+  [above             (-> Painter Painter Painter)]
+  [above3            (-> Painter Painter Painter Painter)]
+  [below             (-> Painter Painter Painter)]
+
+  ;;;
+  ;;; Predefined Basic Painters
+  ;;;
+  [black            Painter]
+  [white            Painter]
+  [gray             Painter]
+  [diagonal-shading Painter]
+  [mark-of-zorro    Painter]
+  [einstein         Painter]
+  [escher           (-> Painter)])
+
+(unsafe-require/typed/provide "../../sicp-pict/main.rkt"
+  [color-object? (pred (Instance Color%))]
+  [pen-object?   (pred (Instance Pen%))]
+  [brush-object? (pred (Instance Brush%))])
+
+
+(provide (all-from-out "../../sicp-pict/main.rkt")
+         (all-defined-out))

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -56,7 +56,7 @@
   [vects->segments (-> (Sequenceof Vect) (Listof Segment))]
 
   ;;;
-  ;;; COLORS, PENS, AND, BRUSHES
+  ;;; Colors, Pens, and Brushes
   ;;;
   [new-color         (case-> (->* (Real Real Real) (Real) (Instance Color%))
                              (-> (U Number String (Instance Color%)) (Instance Color%)))]
@@ -119,6 +119,9 @@
   ;;;
   ;;;  Current Drawing Context
   ;;;
+
+  ; The original parameter contract will cause
+  ; the program to be very slow in some cases.
   [current-bm (Parameter (Option (Instance Bitmap%)))]
   [current-dc (Parameter (Option (Instance Bitmap-DC%)))])
 

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -70,12 +70,6 @@
   [transparent-brush (Instance Brush%)]
 
   ;;;
-  ;;;  Current Drawing Context
-  ;;;
-  [current-bm (Parameter (Option (Instance Bitmap%)))]
-  [current-dc (Parameter (Option (Instance Bitmap-DC%)))]
-
-  ;;;
   ;;; Primitive Painters
   ;;;
   [paint              (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
@@ -120,7 +114,13 @@
 (unsafe-require/typed/provide "../../sicp-pict/main.rkt"
   [color-object? (pred (Instance Color%))]
   [pen-object?   (pred (Instance Pen%))]
-  [brush-object? (pred (Instance Brush%))])
+  [brush-object? (pred (Instance Brush%))]
+
+  ;;;
+  ;;;  Current Drawing Context
+  ;;;
+  [current-bm (Parameter (Option (Instance Bitmap%)))]
+  [current-dc (Parameter (Option (Instance Bitmap-DC%)))])
 
 
 (provide (all-from-out "../../sicp-pict/main.rkt")

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -70,11 +70,17 @@
   [transparent-brush (Instance Brush%)]
 
   ;;;
+  ;;;  Current Drawing Context
+  ;;;
+  [current-bm (Parameter (Option (Instance Bitmap%)))]
+  [current-dc (Parameter (Option (Instance Bitmap-DC%)))]
+
+  ;;;
   ;;; Primitive Painters
   ;;;
-  [paint              (-> Painter [#:width Natural] [#:height Natural] (Instance Image-Snip%))]
-  [paint-hires        (-> Painter [#:width Natural] [#:height Natural] (Instance Image-Snip%))]
-  [paint-hi-res       (-> Painter [#:width Natural] [#:height Natural] (Instance Image-Snip%))]
+  [paint              (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
+  [paint-hires        (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
+  [paint-hi-res       (-> Painter [#:width Positive-Integer] [#:height Positive-Integer] (Instance Image-Snip%))]
   [number->painter    (-> Byte Painter)]
   [color->painter     (-> (Instance Color%) Painter)]
   [segments->painter  (-> (Sequenceof Segment) Painter)]

--- a/typed/sicp-pict/main.rkt
+++ b/typed/sicp-pict/main.rkt
@@ -14,12 +14,14 @@
                   with-pen
                   with-brush
                   echo))
+(provide with-transformation with-frame with-pen with-brush echo)
 
 (define-type Vect    vect)
 (define-type Frame   frame)
 (define-type Trans   trans)
 (define-type Segment segment)
 (define-type Painter (-> Frame Any))
+(provide Vect Frame Trans Segment Painter)
 
 (require/typed/provide "../../sicp-pict/main.rkt"
   ;;;
@@ -72,24 +74,12 @@
   ;;;
   ;;; Primitive Painters
   ;;;
-  [paint        (->* (Painter)
-                     (Any
-                      #:width  Positive-Integer
-                      #:height Positive-Integer
-                      #:backing-scale Positive-Real)
-                     (Instance Image-Snip%))]
-  [paint-hires  (->* (Painter)
-                     (Any
-                      #:width  Positive-Integer
-                      #:height Positive-Integer
-                      #:backing-scale Positive-Real)
-                     (Instance Image-Snip%))]
-  [paint-hi-res (->* (Painter)
-                     (Any
-                      #:width  Positive-Integer
-                      #:height Positive-Integer
-                      #:backing-scale Positive-Real)
-                     (Instance Image-Snip%))]
+  [paint (->* (Painter)
+              (Any
+               #:width  Positive-Integer
+               #:height Positive-Integer
+               #:backing-scale Positive-Real)
+              (Instance Image-Snip%))]
   [number->painter    (-> Byte Painter)]
   [color->painter     (-> (Instance Color%) Painter)]
   [segments->painter  (-> (Sequenceof Segment) Painter)]
@@ -125,6 +115,8 @@
   [mark-of-zorro    Painter]
   [einstein         Painter]
   [escher           (-> Painter)])
+(provide (rename-out [paint paint-hi-res])
+         (rename-out [paint paint-hires]))
 
 (unsafe-require/typed/provide "../../sicp-pict/main.rkt"
   [color-object? (pred (Instance Color%))]
@@ -139,7 +131,3 @@
   ; the program to be very slow in some cases.
   [current-bm (Parameter (Option (Instance Bitmap%)))]
   [current-dc (Parameter (Option (Instance Bitmap-DC%)))])
-
-
-(provide (all-from-out "../../sicp-pict/main.rkt")
-         (all-defined-out))

--- a/typed/sicp-pict/test/tests.rkt
+++ b/typed/sicp-pict/test/tests.rkt
@@ -1,0 +1,27 @@
+#lang typed/racket
+
+(require typed/sicp-pict
+         typed/rackunit)
+
+(: get-pixels (-> Painter Bytes))
+(define (get-pixels painter)
+  (define obj (assert (send (paint painter) get-bitmap)))
+  (define width (send obj get-width))
+  (define height (send obj get-height))
+  (define out (make-bytes (* width height 4)))
+  (send obj get-argb-pixels 0 0 width height out)
+  out)
+
+(define rng '(10000 10100))
+
+(check-equal? (apply subbytes (get-pixels einstein) rng)
+              (apply subbytes (get-pixels (flip-horiz (flip-horiz einstein))) rng))
+
+(check-equal? (apply subbytes (get-pixels einstein) rng)
+              (apply subbytes (get-pixels (flip-vert (flip-vert einstein))) rng))
+
+(check-not-equal? (apply subbytes (get-pixels einstein) rng)
+                  (apply subbytes (get-pixels (flip-horiz einstein)) rng))
+
+(check-not-equal? (apply subbytes (get-pixels einstein) rng)
+                  (apply subbytes (get-pixels (flip-vert einstein)) rng))


### PR DESCRIPTION
This PR mainly makes the following changes:
1. [sicp]: improve `amb` (add 2 shortcuts).
2. [sicp]: provide unicode lambda, `1+` `1-` `-1+`, `null`, `compose` .
3. [sicp]: add some stream operators.
4. [typed/sicp-pict]: Add `typed/sicp-pict`
   (warning: the return type of `paint` is `Image-Snip%`,
      which is not supported by TR.
      https://github.com/racket/typed-racket/pull/1236
   update: the current TR already supports `Image-Snip%`.)
5. [sicp-pict]: Add `blank`, which is the identity element of `superpose`.
6. [sicp-pict]: Add more arguments to `paint` (similar to `make-bitmap`).
7. [sicp-pict]: Add `above` function.
8. [sicp-pict]: Improve the contracts of `*->painter` and `new-*` functions.
9. [Document]: `superpose` can accept any number of arguments, not just two.
10. [Document]: `transform-painter` should accept a painter argument.
11. [Document]: The `width` and `height` should be of `exact-positive-integer?` instead of `(and/c positive? integer?)`.
12. [Document]: Add `COLORS, PENS, and BRUSHES` and `Syntactic Sugar` sections.