### PR TITLE
Update info.rkt add #lang sicp to languages in docs index

### DIFF
--- a/sicp-doc/info.rkt
+++ b/sicp-doc/info.rkt
@@ -1,3 +1,3 @@
 #lang info
 
-(define scribblings '(("sicp-manual.scrbl" (multi-page))))
+(define scribblings '(("sicp-manual.scrbl" (multi-page) (language))))


### PR DESCRIPTION
it is clearly a language. Whether it should be included in Teaching I more contentious as it is neither part of the main distribution, not does the book use Racket the language.